### PR TITLE
feat!: relay module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.34.1 # @denopendabot denoland/deno
+          deno-version: v1.36.0 # @denopendabot denoland/deno
 
       - name: Verify formatting
         run: deno fmt --check

--- a/client.ts
+++ b/client.ts
@@ -19,7 +19,8 @@ export * from "./core/nips/01.ts";
 /**
  * A class that represents a remote Nostr Relay.
  */
-export class Relay extends NostrNode<ClientToRelayMessage, LazyWebSocket> {
+export class Relay extends NostrNode<ClientToRelayMessage> {
+  declare ws: LazyWebSocket;
   readonly config: Readonly<RelayConfig>;
 
   readonly #subs = new Map<

--- a/client.ts
+++ b/client.ts
@@ -11,6 +11,7 @@ import type {
 } from "./core/types.ts";
 import { NostrNode, NostrNodeConfig } from "./core/nodes.ts";
 import { NonExclusiveWritableStream } from "./core/streams.ts";
+import { LazyWebSocket } from "./core/websockets.ts";
 import { Lock } from "./core/x/async.ts";
 
 export * from "./core/nips/01.ts";
@@ -18,7 +19,7 @@ export * from "./core/nips/01.ts";
 /**
  * A class that represents a remote Nostr Relay.
  */
-export class Relay extends NostrNode<ClientToRelayMessage> {
+export class Relay extends NostrNode<ClientToRelayMessage, LazyWebSocket> {
   readonly config: Readonly<RelayConfig>;
 
   readonly #subs = new Map<
@@ -33,7 +34,7 @@ export class Relay extends NostrNode<ClientToRelayMessage> {
     const url = typeof init === "string" ? init : init.url;
 
     super( // new NostrNode(
-      () => new WebSocket(url),
+      new LazyWebSocket(url),
       { nbuffer: 10, ...opts },
     );
 
@@ -78,61 +79,55 @@ export class Relay extends NostrNode<ClientToRelayMessage> {
     opts.nbuffer ??= this.config.nbuffer;
 
     const messenger = this.getWriter();
-    const aborter = new AbortController();
-
     let controllerLock: Lock<ReadableStreamDefaultController<NostrEvent<K>>>;
 
-    this.#subs.set(
-      id,
-      new Lock(
-        new NonExclusiveWritableStream<EoseMessage | EventMessage<K>>({
-          write: ([kn, _, ev]): Promise<void> | undefined => {
-            switch (kn) {
-              case "EOSE":
-                this.config.logger?.debug?.(`[eose] ${this.config.name} ${id}`);
-
-                if (opts.realtime) return;
-                return controllerLock.lock((cnt) => cnt.close());
-
-              case "EVENT":
-                this.config.logger?.debug?.(`[event] ${this.config.name}`, ev);
-
-                return controllerLock.lock((cnt) => cnt.enqueue(ev));
+    const writable = new NonExclusiveWritableStream<
+      EoseMessage | EventMessage<K>
+    >({
+      write: ([kind, _, event]): Promise<void> | undefined => {
+        switch (kind) {
+          case "EOSE":
+            this.config.logger?.debug?.(`[eose] ${this.config.name} ${id}`);
+            if (opts.realtime) {
+              return;
             }
-          },
-          close() {
             return controllerLock.lock((cnt) => cnt.close());
-          },
-        }, new CountQueuingStrategy({ highWaterMark: opts.nbuffer }))
-          .getWriter(),
-      ),
-    );
+          case "EVENT":
+            this.config.logger?.debug?.(`[event] ${this.config.name}`, event);
+            return controllerLock.lock((cnt) => cnt.enqueue(event));
+        }
+      },
+      close() {
+        return controllerLock.lock((cnt) => cnt.close());
+      },
+    }, new CountQueuingStrategy({ highWaterMark: opts.nbuffer }));
+
+    this.#subs.set(id, new Lock(writable.getWriter()));
 
     const request = () => messenger.write(["REQ", id, ...[filter].flat()]);
 
     return new ReadableStream<NostrEvent<K>>({
       start: (controller) => {
         controllerLock = new Lock(controller);
-
-        this.ws.addEventListener("open", request, { signal: aborter.signal });
-
-        if (this.ws.status === WebSocket.OPEN) {
+        this.ws.addEventListener("open", request);
+        if (this.ws.readyState === WebSocket.OPEN) {
           return request();
         }
       },
       pull: () => {
-        return this.connected;
+        return this.ws.ready();
       },
-      async cancel() {
-        aborter.abort();
-
-        await messenger.write(["CLOSE", id]);
-        messenger.close();
+      cancel: async () => {
+        this.ws.removeEventListener("open", request);
+        if (this.ws.readyState === WebSocket.OPEN) {
+          await messenger.write(["CLOSE", id]);
+        }
+        await messenger.close();
       },
     }, new CountQueuingStrategy({ highWaterMark: 0 }));
   }
 
-  override async close() {
+  async close() {
     await Promise.all(
       Array.from(this.#subs.values()).map((sub) =>
         sub.lock((writer) => writer.close())

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -11,7 +11,7 @@ export class NostrNode<W extends NostrMessage = NostrMessage>
   protected ws: LazyWebSocket;
 
   constructor(
-    createWebSocket: () => WebSocket,
+    url: string | URL,
     opts: Partial<NostrNodeConfig> = {},
   ) {
     super({
@@ -25,15 +25,11 @@ export class NostrNode<W extends NostrMessage = NostrMessage>
       },
     });
     this.config = { nbuffer: 10, ...opts };
-    this.ws = new LazyWebSocket(createWebSocket, opts?.logger);
+    this.ws = new LazyWebSocket(url);
   }
 
   get status(): WebSocketReadyState {
-    return this.ws.status;
-  }
-
-  get connected(): Promise<void> {
-    return this.ws.ready;
+    return this.ws.readyState;
   }
 }
 

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -5,7 +5,7 @@ import { NonExclusiveWritableStream } from "./streams.ts";
 /**
  * Common base class for relays and clients.
  */
-export class NostrNode<W extends NostrMessage>
+export class NostrNode<W extends NostrMessage = NostrMessage>
   extends NonExclusiveWritableStream<W> {
   readonly config: Readonly<NostrNodeConfig>;
 

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -1,31 +1,38 @@
 import type { Logger, NostrMessage } from "./types.ts";
-import { LazyWebSocket, type WebSocketReadyState } from "./websockets.ts";
+import { WebSocketLike, WebSocketReadyState } from "./websockets.ts";
 import { NonExclusiveWritableStream } from "./streams.ts";
 
 /**
  * Common base class for relays and clients.
  */
-export class NostrNode<W extends NostrMessage = NostrMessage>
+export class NostrNode<W extends NostrMessage>
   extends NonExclusiveWritableStream<W> {
   readonly config: Readonly<NostrNodeConfig>;
-  protected ws: LazyWebSocket;
 
   constructor(
-    url: string | URL,
+    protected ws: WebSocketLike,
     opts: Partial<NostrNodeConfig> = {},
   ) {
     super({
-      write: (msg): Promise<void> => {
+      write: async (msg) => {
         opts.logger?.debug?.("[node] send", msg);
-        return this.ws.send(JSON.stringify(msg));
+        await this.ws.send(JSON.stringify(msg));
       },
-      close: (): Promise<void> => {
+      close: async () => {
         opts.logger?.debug?.("[node] close");
-        return this.ws.close();
+        await this.ws.close();
       },
     });
     this.config = { nbuffer: 10, ...opts };
-    this.ws = new LazyWebSocket(url);
+    this.ws.addEventListener("open", () => {
+      opts.logger?.debug?.("[ws] open");
+    });
+    this.ws.addEventListener("close", () => {
+      opts.logger?.debug?.("[ws] close");
+    });
+    this.ws.addEventListener("message", (ev) => {
+      opts.logger?.debug?.("[ws] recv", ev.data);
+    });
   }
 
   get status(): WebSocketReadyState {

--- a/core/nodes_test.ts
+++ b/core/nodes_test.ts
@@ -1,5 +1,4 @@
 import { NostrNode } from "./nodes.ts";
-import { RelayToClientMessage } from "../core/nips/01.ts";
 import {
   afterAll,
   assert,
@@ -11,7 +10,7 @@ import {
 import { MockWebSocket } from "../lib/testing.ts";
 
 describe("NostrNode", () => {
-  let node: NostrNode<RelayToClientMessage, WebSocket>;
+  let node: NostrNode;
 
   beforeAll(() => {
     node = new NostrNode(new MockWebSocket());

--- a/core/nodes_test.ts
+++ b/core/nodes_test.ts
@@ -1,10 +1,9 @@
 import { NostrNode } from "./nodes.ts";
 import {
-  afterEach,
+  afterAll,
   assert,
   assertEquals,
-  assertFalse,
-  beforeEach,
+  beforeAll,
   describe,
   it,
 } from "../lib/std/testing.ts";
@@ -14,17 +13,13 @@ describe("NostrNode", () => {
   const url = "wss://localhost:8080";
   let server: Server;
   let node: NostrNode;
-  let ws: WebSocket;
 
-  beforeEach(() => {
+  beforeAll(() => {
     server = new Server(url);
-    node = new NostrNode(() => {
-      ws = new WebSocket(url);
-      return ws;
-    });
+    node = new NostrNode(url);
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await node.close().catch((err) => {
       if (err.message !== "Writable stream is closed or errored.") {
         throw err;
@@ -34,22 +29,21 @@ describe("NostrNode", () => {
   });
 
   it("should be able to create a NostrNode instance", () => {
-    assert(node);
+    assert(node instanceof NostrNode);
   });
 
   it("should not connect to the WebSocket when created", () => {
-    assertFalse(ws instanceof WebSocket);
+    assertEquals(node.status, WebSocket.CLOSED);
   });
 
   it("should connect to the WebSocket when a message is sent", async () => {
     await node.getWriter().write(["NOTICE", "test"]);
-    assert(ws instanceof WebSocket);
-    assertEquals(ws.readyState, WebSocket.OPEN);
+    assertEquals(node.status, WebSocket.OPEN);
   });
 
   it("should close the WebSocket when the node is closed", async () => {
     await node.getWriter().write(["NOTICE", "test"]);
     await node.close();
-    assertEquals(ws.readyState, WebSocket.CLOSED);
+    assertEquals(node.status, WebSocket.CLOSED);
   });
 });

--- a/core/nodes_test.ts
+++ b/core/nodes_test.ts
@@ -1,4 +1,5 @@
 import { NostrNode } from "./nodes.ts";
+import { RelayToClientMessage } from "../core/nips/01.ts";
 import {
   afterAll,
   assert,
@@ -7,16 +8,13 @@ import {
   describe,
   it,
 } from "../lib/std/testing.ts";
-import { Server, WebSocket } from "../lib/x/mock-socket.ts";
+import { MockWebSocket } from "../lib/testing.ts";
 
 describe("NostrNode", () => {
-  const url = "wss://localhost:8080";
-  let server: Server;
-  let node: NostrNode;
+  let node: NostrNode<RelayToClientMessage, WebSocket>;
 
   beforeAll(() => {
-    server = new Server(url);
-    node = new NostrNode(url);
+    node = new NostrNode(new MockWebSocket());
   });
 
   afterAll(async () => {
@@ -25,18 +23,13 @@ describe("NostrNode", () => {
         throw err;
       }
     });
-    server.close();
   });
 
   it("should be able to create a NostrNode instance", () => {
     assert(node instanceof NostrNode);
   });
 
-  it("should not connect to the WebSocket when created", () => {
-    assertEquals(node.status, WebSocket.CLOSED);
-  });
-
-  it("should connect to the WebSocket when a message is sent", async () => {
+  it("should be connected to the WebSocket after a message is sent", async () => {
     await node.getWriter().write(["NOTICE", "test"]);
     assertEquals(node.status, WebSocket.OPEN);
   });

--- a/core/websockets.ts
+++ b/core/websockets.ts
@@ -44,17 +44,10 @@ export class LazyWebSocket implements WebSocketLike {
       ws.addEventListener("open", () => {
         this.#notifier.notifyAll();
       });
-      this.#eventListenerMap.get("open")?.forEach((_, listener) => {
-        return listener instanceof Function
-          ? listener.call(ws, new Event("open"))
-          : listener.handleEvent(new Event("open"));
-      });
       this.#eventListenerMap.forEach((map, type) => {
-        if (type !== "open") {
-          map.forEach((options, listener) => {
-            ws.addEventListener(type, listener, options);
-          });
-        }
+        map.forEach((options, listener) => {
+          ws.addEventListener(type, listener, options);
+        });
       });
       return ws;
     };

--- a/core/websockets.ts
+++ b/core/websockets.ts
@@ -41,9 +41,11 @@ export class LazyWebSocket implements WebSocketLike {
   ) {
     this.#createWebSocket = () => {
       const ws = new WebSocket(url, protocols);
-      ws.addEventListener("open", () => {
-        this.#notifier.notifyAll();
-      });
+      for (const type of ["close", "open"] as const) {
+        ws.addEventListener(type, () => {
+          this.#notifier.notifyAll();
+        });
+      }
       this.#eventListenerMap.forEach((map, type) => {
         map.forEach((options, listener) => {
           ws.addEventListener(type, listener, options);

--- a/core/websockets_test.ts
+++ b/core/websockets_test.ts
@@ -7,16 +7,16 @@ import {
   it,
 } from "../lib/std/testing.ts";
 import { LazyWebSocket } from "./websockets.ts";
-import { MockWebSocket as WebSocket } from "../lib/testing.ts";
+import { MockWebSocket } from "../lib/testing.ts";
 
 describe("LazyWebSocket", () => {
   let lazy: LazyWebSocket;
-  let socket: WebSocket;
-  let server: WebSocket;
+  let socket: MockWebSocket;
+  let server: MockWebSocket;
   let opened: Promise<true>
 
   beforeAll(() => {
-    globalThis.WebSocket = WebSocket;
+    globalThis.WebSocket = MockWebSocket;
     lazy = new LazyWebSocket("wss://localhost:8080");
   });
 
@@ -52,7 +52,7 @@ describe("LazyWebSocket", () => {
     const errored = new Promise((resolve) => {
       lazy.addEventListener("error", resolve);
     });
-    socket = WebSocket.instances[0];
+    socket = MockWebSocket.instances[0];
     socket.dispatchEvent(new Event("error"));
     await errored;
   });

--- a/core/websockets_test.ts
+++ b/core/websockets_test.ts
@@ -13,7 +13,7 @@ describe("LazyWebSocket", () => {
   let lazy: LazyWebSocket;
   let socket: MockWebSocket;
   let server: MockWebSocket;
-  let opened: Promise<true>
+  let opened: Promise<true>;
 
   beforeAll(() => {
     globalThis.WebSocket = MockWebSocket;

--- a/core/websockets_test.ts
+++ b/core/websockets_test.ts
@@ -10,7 +10,6 @@ import {
 } from "../lib/std/testing.ts";
 import { Server } from "../lib/x/mock-socket.ts";
 import { LazyWebSocket } from "./websockets.ts";
-import { Notify } from "./x/async.ts";
 
 describe("LazyWebSocket", () => {
   let server: Server;
@@ -23,9 +22,9 @@ describe("LazyWebSocket", () => {
     lazy = new LazyWebSocket(url);
   });
 
-  afterAll(() => {
-    server.close();
-    lazy.close();
+  afterAll(async () => {
+    await lazy.close();
+    server.stop();
   });
 
   it("should be able to create a LazyWebSocket instance", () => {
@@ -43,21 +42,21 @@ describe("LazyWebSocket", () => {
     assertEquals(lazy.readyState, WebSocket.CLOSED);
   });
 
-  // it("should trigger the onopen event when an event is sent", async () => {
-  //   await lazy.send("test");
-  //   assert(await promise);
-  // });
+  it("should trigger the onopen event when an event is sent", async () => {
+    await lazy.send("test");
+    assert(await promise);
+  });
 
-//   it("should open the WebSocket when an event is sent", () => {
-//     assertEquals(lazy.readyState, WebSocket.OPEN);
-//   });
+  it("should open the WebSocket when an event is sent", () => {
+    assertEquals(lazy.readyState, WebSocket.OPEN);
+  });
 
   it("should trigger the onerror event when the WebSocket errors", async () => {
     await lazy.ready();
     const errored = new Promise((resolve) => {
       lazy.addEventListener("error", resolve);
     });
-    lazy.dispatchEvent(new Event("error"));
+    server.emit("error", new Error("test"));
     await errored;
   });
 
@@ -75,12 +74,12 @@ describe("LazyWebSocket", () => {
     const closed = new Promise((resolve) => {
       lazy.addEventListener("close", resolve);
     });
-    lazy.dispatchEvent(new CloseEvent("close"));
+    server.emit("close", null);
     await closed;
   });
 
-//   it("should close the WebSocket when the LazyWebSocket is closed", () => {
-//     lazy.close();
-//     assertEquals(lazy.readyState, WebSocket.CLOSED);
-//   });
+  it("should close the WebSocket when the LazyWebSocket is closed", async () => {
+    await lazy.close();
+    assertEquals(lazy.readyState, WebSocket.CLOSED);
+  });
 });

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,4 +1,4 @@
-export class MockWebSocket implements WebSocket {
+export class MockWebSocket extends EventTarget implements WebSocket {
   readonly CONNECTING = WebSocket.CONNECTING;
   readonly OPEN = WebSocket.OPEN;
   readonly CLOSING = WebSocket.CLOSING;
@@ -28,6 +28,7 @@ export class MockWebSocket implements WebSocket {
   }
 
   constructor(url?: string | URL, protocols?: string | string[]) {
+    super();
     this.url = url?.toString() ?? "";
     this.protocol = protocols ? protocols.toString() : "";
   }
@@ -56,30 +57,15 @@ export class MockWebSocket implements WebSocket {
     }
   }
 
-  onclose: ((this: WebSocket, ev: CloseEvent) => void) | null = null;
-  onerror: ((this: WebSocket, ev: Event) => void) | null = null;
-  onmessage: ((this: WebSocket, ev: MessageEvent) => void) | null = null;
-  onopen: ((this: WebSocket, ev: Event) => void) | null = null;
+  addEventListener: WebSocket["addEventListener"] = super.addEventListener;
+  removeEventListener: WebSocket["removeEventListener"] = super
+    .removeEventListener;
+  dispatchEvent: WebSocket["dispatchEvent"] = super.dispatchEvent;
 
-  addEventListener(
-    _type: string,
-    _listener: EventListenerOrEventListenerObject | null,
-    _options?: boolean | AddEventListenerOptions,
-  ): void {
-    throw new Error("Method not implemented.");
-  }
-
-  removeEventListener(
-    _type: string,
-    _callback: EventListenerOrEventListenerObject | null,
-    _options?: EventListenerOptions | boolean,
-  ): void {
-    throw new Error("Method not implemented.");
-  }
-
-  dispatchEvent(_event: Event): boolean {
-    throw new Error("Method not implemented.");
-  }
+  onclose: WebSocket["onclose"] = null;
+  onerror: WebSocket["onerror"] = null;
+  onmessage: WebSocket["onmessage"] = null;
+  onopen: WebSocket["onopen"] = null;
 }
 
 type MessageEventData = string | ArrayBufferLike | Blob | ArrayBufferView;

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,36 +1,59 @@
 export class MockWebSocket implements WebSocket {
-  CONNECTING = WebSocket.CONNECTING;
-  OPEN = WebSocket.OPEN;
-  CLOSING = WebSocket.CLOSING;
-  CLOSED = WebSocket.CLOSED;
+  readonly CONNECTING = WebSocket.CONNECTING;
+  readonly OPEN = WebSocket.OPEN;
+  readonly CLOSING = WebSocket.CLOSING;
+  readonly CLOSED = WebSocket.CLOSED;
 
   binaryType: "blob" | "arraybuffer" = "blob";
   readonly bufferedAmount: number = 0;
   readonly extensions: string = "";
-  readonly protocol: string = "";
+  readonly protocol: string;
+  readonly url: string;
 
   #readyState: number = WebSocket.OPEN;
   get readyState(): number {
     return this.#readyState;
   }
 
-  readonly url: string = "";
+  #stream_outgoing?: TransformStream<Event>;
+  #stream_incoming?: TransformStream<MessageEventData>;
 
-  readonly close: (code?: number, reason?: string) => void;
-  readonly send: (
-    data: string | ArrayBufferLike | Blob | ArrayBufferView,
-  ) => void;
+  get readable() {
+    this.#stream_outgoing ??= new TransformStream<Event>();
+    return this.#stream_outgoing.readable;
+  }
+  get writable() {
+    this.#stream_incoming ??= new TransformStream<MessageEventData>();
+    return this.#stream_incoming.writable;
+  }
 
-  constructor(
-    onclosed?: (code?: number, reason?: string) => void,
-    onsent?: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void,
-  ) {
-    this.close = (code?: number, reason?: string) => {
-      return onclosed?.(code, reason);
-    };
-    this.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
-      return onsent?.(data);
-    };
+  constructor(url?: string | URL, protocols?: string | string[]) {
+    this.url = url?.toString() ?? "";
+    this.protocol = protocols ? protocols.toString() : "";
+  }
+
+  async close(code?: number, reason?: string): Promise<void> {
+    this.#readyState = WebSocket.CLOSING;
+    const writer = this.#stream_outgoing?.writable.getWriter();
+    if (writer) {
+      await writer.ready;
+      await writer.write(
+        new CloseEvent("close", { code, reason, wasClean: true }),
+      );
+      await writer.close();
+    }
+    this.#readyState = WebSocket.CLOSED;
+  }
+
+  async send(data: MessageEventData): Promise<void> {
+    const writer = this.#stream_outgoing?.writable.getWriter();
+    if (writer) {
+      await writer.ready;
+      await writer.write(
+        new MessageEvent("message", { data }),
+      );
+      writer.releaseLock();
+    }
   }
 
   onclose: ((this: WebSocket, ev: CloseEvent) => void) | null = null;
@@ -45,6 +68,7 @@ export class MockWebSocket implements WebSocket {
   ): void {
     throw new Error("Method not implemented.");
   }
+
   removeEventListener(
     _type: string,
     _callback: EventListenerOrEventListenerObject | null,
@@ -52,7 +76,10 @@ export class MockWebSocket implements WebSocket {
   ): void {
     throw new Error("Method not implemented.");
   }
+
   dispatchEvent(_event: Event): boolean {
     throw new Error("Method not implemented.");
   }
 }
+
+type MessageEventData = string | ArrayBufferLike | Blob | ArrayBufferView;

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -11,6 +11,12 @@ export class MockWebSocket extends EventTarget implements WebSocket {
     this.url = url?.toString() ?? "";
     this.protocol = protocols ? [...protocols].flat()[0] : "";
     MockWebSocket.#instances.push(this);
+
+    // Simulate a slow opening of a WebSocket as much as possible.
+    queueMicrotask(() => {
+      this.#readyState = 1;
+      this.dispatchEvent(new Event("open"));
+    });
   }
 
   binaryType: "blob" | "arraybuffer" = "blob";
@@ -27,7 +33,7 @@ export class MockWebSocket extends EventTarget implements WebSocket {
   get readyState(): number {
     return this.#readyState;
   }
-  #readyState: number = this.OPEN;
+  #readyState = 0;
 
   get remote(): MockWebSocket {
     if (!this.#remote) {

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,8 +1,17 @@
-export class MockWebSocket extends EventTarget implements WebSocket {
-  readonly CONNECTING = WebSocket.CONNECTING;
-  readonly OPEN = WebSocket.OPEN;
-  readonly CLOSING = WebSocket.CLOSING;
-  readonly CLOSED = WebSocket.CLOSED;
+type MessageEventData = string | ArrayBufferLike | Blob | ArrayBufferView;
+
+export class MockWebSocket extends EventTarget implements globalThis.WebSocket {
+  static get instances(): MockWebSocket[] {
+    return this.#instances;
+  }
+  static #instances: MockWebSocket[] = [];
+
+  constructor(url?: string | URL, protocols?: string | string[]) {
+    super();
+    this.url = url?.toString() ?? "";
+    this.protocol = protocols ? [...protocols].flat()[0] : "";
+    MockWebSocket.#instances.push(this);
+  }
 
   binaryType: "blob" | "arraybuffer" = "blob";
   readonly bufferedAmount: number = 0;
@@ -10,62 +19,53 @@ export class MockWebSocket extends EventTarget implements WebSocket {
   readonly protocol: string;
   readonly url: string;
 
-  #readyState: number = WebSocket.OPEN;
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
   get readyState(): number {
     return this.#readyState;
   }
+  #readyState: number = this.OPEN;
 
-  #stream_outgoing?: TransformStream<Event>;
-  #stream_incoming?: TransformStream<MessageEventData>;
-
-  get readable() {
-    this.#stream_outgoing ??= new TransformStream<Event>();
-    return this.#stream_outgoing.readable;
-  }
-  get writable() {
-    this.#stream_incoming ??= new TransformStream<MessageEventData>();
-    return this.#stream_incoming.writable;
-  }
-
-  constructor(url?: string | URL, protocols?: string | string[]) {
-    super();
-    this.url = url?.toString() ?? "";
-    this.protocol = protocols ? protocols.toString() : "";
-  }
-
-  async close(code?: number, reason?: string): Promise<void> {
-    this.#readyState = WebSocket.CLOSING;
-    const writer = this.#stream_outgoing?.writable.getWriter();
-    if (writer) {
-      await writer.ready;
-      await writer.write(
-        new CloseEvent("close", { code, reason, wasClean: true }),
-      );
-      await writer.close();
+  get remote(): MockWebSocket {
+    if (!this.#remote) {
+      this.#remote = new MockWebSocket(this.url);
+      this.#remote.#remote = this;
     }
-    this.#readyState = WebSocket.CLOSED;
+    return this.#remote;
   }
+  #remote: MockWebSocket | undefined;
 
-  async send(data: MessageEventData): Promise<void> {
-    const writer = this.#stream_outgoing?.writable.getWriter();
-    if (writer) {
-      await writer.ready;
-      await writer.write(
-        new MessageEvent("message", { data }),
-      );
-      writer.releaseLock();
+  close(code?: number, reason?: string): void {
+    this.#readyState = 2;
+    if (this.#remote) {
+      this.#remote.#readyState = 3;
+      this.#remote.dispatchEvent(new CloseEvent("close", { code, reason }));
     }
+    this.#readyState = 3;
   }
 
-  addEventListener: WebSocket["addEventListener"] = super.addEventListener;
-  removeEventListener: WebSocket["removeEventListener"] = super
-    .removeEventListener;
-  dispatchEvent: WebSocket["dispatchEvent"] = super.dispatchEvent;
+  send(data: MessageEventData): void {
+    this.#remote?.dispatchEvent(new MessageEvent("message", { data }));
+  }
 
-  onclose: WebSocket["onclose"] = null;
-  onerror: WebSocket["onerror"] = null;
-  onmessage: WebSocket["onmessage"] = null;
-  onopen: WebSocket["onopen"] = null;
+  onclose = null;
+  onerror = null;
+  onmessage = null;
+  onopen = null;
+
+  static get CONNECTING(): number {
+    return this.CONNECTING;
+  }
+  static get OPEN(): number {
+    return this.OPEN;
+  }
+  static get CLOSING(): number {
+    return this.CLOSING;
+  }
+  static get CLOSED(): number {
+    return this.CLOSED;
+  }
 }
-
-type MessageEventData = string | ArrayBufferLike | Blob | ArrayBufferView;

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -65,6 +65,11 @@ export class MockWebSocket extends EventTarget implements WebSocket {
   onmessage = null;
   onopen = null;
 
+  addEventListener: WebSocket["addEventListener"] = super.addEventListener;
+  removeEventListener: WebSocket["removeEventListener"] = super
+    .removeEventListener;
+  dispatchEvent: WebSocket["dispatchEvent"] = super.dispatchEvent;
+
   static get CONNECTING(): number {
     return 0;
   }

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,0 +1,56 @@
+export class MockWebSocket implements WebSocket {
+  CONNECTING = WebSocket.CONNECTING;
+  OPEN = WebSocket.OPEN;
+  CLOSING = WebSocket.CLOSING;
+  CLOSED = WebSocket.CLOSED;
+
+  binaryType: "blob" | "arraybuffer" = "blob";
+  readonly bufferedAmount: number = 0;
+  readonly extensions: string = "";
+  readonly protocol: string = "";
+
+  #readyState: number = WebSocket.OPEN;
+  get readyState(): number {
+    return this.#readyState;
+  }
+
+  readonly url: string = "";
+
+  close: (code?: number, reason?: string) => void;
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+
+  constructor(
+    onclosed?: (code?: number, reason?: string) => void,
+    onsent?: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void,
+  ) {
+    this.close = (code?: number, reason?: string) => {
+      return onclosed?.(code, reason);
+    }
+    this.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+      return onsent?.(data);
+    }
+  }
+
+  onclose: ((this: WebSocket, ev: CloseEvent) => void) | null = null;
+  onerror: ((this: WebSocket, ev: Event) => void) | null = null;
+  onmessage: ((this: WebSocket, ev: MessageEvent) => void) | null = null;
+  onopen: ((this: WebSocket, ev: Event) => void) | null = null;
+
+  addEventListener(
+    _type: string,
+    _listener: EventListenerOrEventListenerObject | null,
+    _options?: boolean | AddEventListenerOptions,
+  ): void {
+    throw new Error("Method not implemented.");
+  }
+  removeEventListener(
+    _type: string,
+    _callback: EventListenerOrEventListenerObject | null,
+    _options?: EventListenerOptions | boolean,
+  ): void {
+    throw new Error("Method not implemented.");
+  }
+  dispatchEvent(_event: Event): boolean {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,6 +1,6 @@
 type MessageEventData = string | ArrayBufferLike | Blob | ArrayBufferView;
 
-export class MockWebSocket extends EventTarget implements globalThis.WebSocket {
+export class MockWebSocket extends EventTarget implements WebSocket {
   static get instances(): MockWebSocket[] {
     return this.#instances;
   }
@@ -57,15 +57,15 @@ export class MockWebSocket extends EventTarget implements globalThis.WebSocket {
   onopen = null;
 
   static get CONNECTING(): number {
-    return this.CONNECTING;
+    return 0;
   }
   static get OPEN(): number {
-    return this.OPEN;
+    return 1;
   }
   static get CLOSING(): number {
-    return this.CLOSING;
+    return 2;
   }
   static get CLOSED(): number {
-    return this.CLOSED;
+    return 3;
   }
 }

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -11,7 +11,6 @@ export class MockWebSocket extends EventTarget implements WebSocket {
     this.url = url?.toString() ?? "";
     this.protocol = protocols ? [...protocols].flat()[0] : "";
     MockWebSocket.#instances.push(this);
-
     // Simulate a slow opening of a WebSocket as much as possible.
     queueMicrotask(() => {
       this.#readyState = 1;
@@ -46,11 +45,15 @@ export class MockWebSocket extends EventTarget implements WebSocket {
 
   close(code?: number, reason?: string): void {
     this.#readyState = 2;
-    if (this.#remote) {
-      this.#remote.#readyState = 3;
-      this.#remote.dispatchEvent(new CloseEvent("close", { code, reason }));
-    }
-    this.#readyState = 3;
+    // Simulate a slow closing of a WebSocket as much as possible.
+    queueMicrotask(() => {
+      if (this.#remote) {
+        this.#remote.#readyState = 3;
+        this.#remote.dispatchEvent(new CloseEvent("close", { code, reason }));
+      }
+      this.#readyState = 3;
+      this.dispatchEvent(new CloseEvent("close", { code, reason }));
+    });
   }
 
   send(data: MessageEventData): void {

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -16,8 +16,10 @@ export class MockWebSocket implements WebSocket {
 
   readonly url: string = "";
 
-  close: (code?: number, reason?: string) => void;
-  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+  readonly close: (code?: number, reason?: string) => void;
+  readonly send: (
+    data: string | ArrayBufferLike | Blob | ArrayBufferView,
+  ) => void;
 
   constructor(
     onclosed?: (code?: number, reason?: string) => void,
@@ -25,10 +27,10 @@ export class MockWebSocket implements WebSocket {
   ) {
     this.close = (code?: number, reason?: string) => {
       return onclosed?.(code, reason);
-    }
+    };
     this.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
       return onsent?.(data);
-    }
+    };
   }
 
   onclose: ((this: WebSocket, ev: CloseEvent) => void) | null = null;

--- a/lib/testing_test.ts
+++ b/lib/testing_test.ts
@@ -53,8 +53,12 @@ describe("MockWebSocket", () => {
         ws.remote.addEventListener("close", () => resolve(true));
       });
     });
-    it("should close the WebSocket", () => {
+    it("should close the WebSocket", async () => {
+      const closed = new Promise<true>((resolve) => {
+        ws.addEventListener("close", () => resolve(true));
+      });
       ws.close();
+      assert(await closed);
       assertEquals(ws.readyState, WebSocket.CLOSED);
     });
     it("should close the remote WebSocket", () => {

--- a/lib/testing_test.ts
+++ b/lib/testing_test.ts
@@ -1,0 +1,21 @@
+import {
+  assert,
+  assertEquals,
+  beforeAll,
+  afterAll,
+  describe,
+  it,
+} from "../lib/std/testing.ts";
+import { MockWebSocket } from "../lib/testing.ts";
+
+describe("MockWebSocket", () => {
+  it("should be able to create a MockWebSocket instance", () => {
+    const ws = new MockWebSocket();
+    assert(ws instanceof MockWebSocket);
+  });
+  it("should be able to send a message", () => {
+    const ws = new MockWebSocket();
+    ws.send("test");
+    // assertEquals(ws.sent, ["test"]);
+  });
+});

--- a/lib/testing_test.ts
+++ b/lib/testing_test.ts
@@ -1,5 +1,4 @@
 import {
-  afterAll,
   assert,
   assertEquals,
   beforeAll,

--- a/relay.ts
+++ b/relay.ts
@@ -1,6 +1,6 @@
 import type {
-  RelayToClientMessage,
   ClientToRelayMessage,
+  RelayToClientMessage,
 } from "./core/types.ts";
 import { NostrNode, NostrNodeConfig } from "./core/nodes.ts";
 import { Lock } from "./core/x/async.ts";

--- a/relay.ts
+++ b/relay.ts
@@ -3,6 +3,7 @@ import type {
   RelayToClientMessage,
 } from "./core/types.ts";
 import { NostrNode, NostrNodeConfig } from "./core/nodes.ts";
+import { LazyWebSocket } from "./core/websockets.ts";
 import { Lock } from "./core/x/async.ts";
 
 class ConnectionError extends Error {}
@@ -10,7 +11,7 @@ class ConnectionError extends Error {}
 /**
  * A class that represents a remote Nostr client.
  */
-export class Client extends NostrNode<RelayToClientMessage> {
+export class Client extends NostrNode<RelayToClientMessage, LazyWebSocket> {
   constructor(
     ws: WebSocket,
     opts?: ClientOptions,

--- a/relay.ts
+++ b/relay.ts
@@ -1,0 +1,42 @@
+import type {
+  RelayToClientMessage,
+  ClientToRelayMessage,
+} from "./core/types.ts";
+import { NostrNode, NostrNodeConfig } from "./core/nodes.ts";
+import { Lock } from "./core/x/async.ts";
+
+class ConnectionError extends Error {}
+
+/**
+ * A class that represents a remote Nostr client.
+ */
+export class Client extends NostrNode<RelayToClientMessage> {
+  constructor(
+    ws: WebSocket,
+    opts?: ClientOptions,
+  ) {
+    super( // new NostrNode(
+      () => {
+        if (ws.readyState >= WebSocket.CLOSING) {
+          throw new ConnectionError("WebSocket is closing or closed");
+        }
+        return ws;
+      },
+      { nbuffer: 10, ...opts },
+    );
+    // const messenger = new Lock(this.getWriter());
+    this.ws.addEventListener("message", (ev: MessageEvent<string>) => {
+      // TODO: Validate the type of the message.
+      const msg = JSON.parse(ev.data) as ClientToRelayMessage;
+      // TODO: Apply backpressure when a queue is full.
+      if (msg[0] === "EVENT") {
+        // TODO: Handle event (write to stream, database, etc.).
+        return;
+      }
+      const subid = msg[1];
+    });
+  }
+}
+
+export type ClientConfig = NostrNodeConfig;
+export type ClientOptions = Partial<ClientConfig>;

--- a/tests/client_test.ts
+++ b/tests/client_test.ts
@@ -2,16 +2,14 @@ import {
   ClientToRelayMessage,
   Relay,
   RelayToClientMessage,
+  NostrEvent,
 } from "../client.ts";
-import { pop } from "../lib/x/streamtools.ts";
 import {
   afterAll,
-  afterEach,
   assert,
   assertEquals,
   assertObjectMatch,
   beforeAll,
-  beforeEach,
   describe,
   it,
 } from "../lib/std/testing.ts";
@@ -86,12 +84,15 @@ describe("Relay", () => {
   const url = "wss://localhost:8080";
   let server: Server;
   let relay: Relay;
+  let sub: ReadableStream<NostrEvent<1>>;
 
-  beforeEach(() => {
+  beforeAll(() => {
     server = new Server(url);
     server.on("connection", (ws) => {
       ws.on("message", (data) => {
-        if (typeof data !== "string") throw new Error();
+        if (typeof data !== "string") {
+          throw new Error();
+        }
         const msg = JSON.parse(data) as ClientToRelayMessage;
         if (msg[0] === "REQ") {
           ws.send(JSON.stringify(
@@ -102,13 +103,14 @@ describe("Relay", () => {
               { kind: 1 } as any,
             ] satisfies RelayToClientMessage,
           ));
+          console.debug("sent");
         }
       });
     });
-    relay = new Relay(url);
+    relay = new Relay(url, { logger: console });
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await relay.close();
     server.close();
   });
@@ -118,26 +120,27 @@ describe("Relay", () => {
   });
 
   it("should not connect when a subscription is created", () => {
-    relay.subscribe({ kinds: [1] });
+    sub = relay.subscribe({ kinds: [1] });
     assertEquals(relay.status, WebSocket.CLOSED);
   });
 
   it("should receive text notes", async () => {
-    const sub = relay.subscribe({ kinds: [1] });
-    assert(await pop(sub));
+    for await (const event of sub) {
+      console.debug(event);
+    }
   });
 
-  it("should be able to open multiple subscriptions", () => {
-    const sub1 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
-    const sub2 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
-    assert(sub1);
-    assert(sub2);
-  });
+//   it("should be able to open multiple subscriptions", () => {
+//     const sub1 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
+//     const sub2 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
+//     assert(sub1);
+//     assert(sub2);
+//   });
 
-  it("should recieve metas and notes simultaneously", async () => {
-    const sub1 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
-    const sub2 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
-    assert(await pop(sub1));
-    assert(await pop(sub2));
-  });
+//   it("should recieve metas and notes simultaneously", async () => {
+//     const sub1 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
+//     const sub2 = relay.subscribe({ kinds: [1], limit: 1 }, { realtime: false });
+//     assert(await pop(sub1));
+//     assert(await pop(sub2));
+//   });
 });

--- a/tests/client_test.ts
+++ b/tests/client_test.ts
@@ -8,7 +8,7 @@ import {
   describe,
   it,
 } from "../lib/std/testing.ts";
-import { MockWebSocket as WebSocket } from "../lib/testing.ts";
+import { MockWebSocket } from "../lib/testing.ts";
 
 const url = "wss://localhost:8080";
 
@@ -82,7 +82,7 @@ describe("Relay", () => {
   let sub_1: ReadableStream<NostrEvent<1>>;
 
   beforeAll(() => {
-    globalThis.WebSocket = WebSocket;
+    globalThis.WebSocket = MockWebSocket;
     relay = new Relay(url);
   });
 
@@ -103,7 +103,7 @@ describe("Relay", () => {
   it("should receive text notes", async () => {
     const reader = sub_1.getReader();
     const read = reader.read();
-    const ws = WebSocket.instances[0];
+    const ws = MockWebSocket.instances[0];
     ws.dispatchEvent(
       new MessageEvent("message", {
         data: JSON.stringify(["EVENT", "test-1", { kind: 1 }]),
@@ -123,7 +123,7 @@ describe("Relay", () => {
   it("should recieve metas and notes simultaneously", async () => {
     const read_0 = sub_0.getReader().read();
     const read_1 = sub_1.getReader().read();
-    const ws = WebSocket.instances[0];
+    const ws = MockWebSocket.instances[0];
     ws.dispatchEvent(
       new MessageEvent("message", {
         data: JSON.stringify(["EVENT", "test-0", { kind: 0 }]),

--- a/tests/relay_test.ts
+++ b/tests/relay_test.ts
@@ -4,6 +4,7 @@ import {
   afterEach,
   assert,
   assertEquals,
+  assertThrows,
   assertObjectMatch,
   beforeAll,
   beforeEach,
@@ -13,8 +14,8 @@ import {
 import { MockWebSocket } from "../lib/testing.ts";
 
 describe("Client", () => {
-  describe("new Client()", () => {
-    let ws: WebSocket;
+  describe("constructor", () => {
+    let ws: MockWebSocket;
     let client: Client;
     beforeAll(() => {
       ws = new MockWebSocket();
@@ -22,8 +23,7 @@ describe("Client", () => {
     });
     afterAll(async () => {
       await client.close();
-      ws.close();
-      // wait for 1 second to allow the server to close the connection.
+      await ws.close();
     });
     it("should create a Client instance", () => {
       assert(client instanceof Client);

--- a/tests/relay_test.ts
+++ b/tests/relay_test.ts
@@ -1,0 +1,32 @@
+import { Client } from "../relay.ts";
+import {
+  afterAll,
+  afterEach,
+  assert,
+  assertEquals,
+  assertObjectMatch,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "../lib/std/testing.ts";
+import { MockWebSocket } from "../lib/testing.ts";
+
+describe("Client", () => {
+  describe("new Client()", () => {
+    let ws: WebSocket;
+    let client: Client;
+    beforeAll(() => {
+      ws = new MockWebSocket();
+      client = new Client(ws, { logger: { error: console.error } });
+    });
+    afterAll(async () => {
+      await client.close();
+      ws.close();
+      // wait for 1 second to allow the server to close the connection.
+    });
+    it("should create a Client instance", () => {
+      assert(client instanceof Client);
+    });
+  });
+});

--- a/tests/relay_test.ts
+++ b/tests/relay_test.ts
@@ -1,31 +1,48 @@
 import { Client } from "../relay.ts";
 import {
   afterAll,
-  afterEach,
   assert,
   assertEquals,
   assertObjectMatch,
   beforeAll,
-  beforeEach,
   describe,
   it,
 } from "../lib/std/testing.ts";
 import { MockWebSocket } from "../lib/testing.ts";
 
 describe("Client", () => {
+  let ws: MockWebSocket;
+  let client: Client;
+
+  beforeAll(() => {
+    ws = new MockWebSocket();
+    client = new Client(ws, { logger: console });
+  });
+  afterAll(() => {
+    client.close();
+  });
+
   describe("constructor", () => {
-    let ws: MockWebSocket;
-    let client: Client;
-    beforeAll(() => {
-      ws = new MockWebSocket();
-      client = new Client(ws, { logger: { error: console.error } });
-    });
-    afterAll(async () => {
-      await client.close();
-      await ws.close();
-    });
     it("should create a Client instance", () => {
       assert(client instanceof Client);
+    });
+  });
+
+  describe("get events()", () => {
+    it("should return a ReadableStream of events", () => {
+      assert(client.events instanceof ReadableStream);
+    });
+  });
+
+  describe("get requests()", () => {
+    it("should return a ReadableStream of requests", () => {
+      assert(client.requests instanceof ReadableStream);
+    });
+  });
+
+  describe("subscriptions", () => {
+    it("should return a Map of subscriptions", () => {
+      assert(client.subscriptions instanceof Map);
     });
   });
 });

--- a/tests/relay_test.ts
+++ b/tests/relay_test.ts
@@ -4,7 +4,6 @@ import {
   afterEach,
   assert,
   assertEquals,
-  assertThrows,
   assertObjectMatch,
   beforeAll,
   beforeEach,


### PR DESCRIPTION
- chore(lib): implement mock websocket for testing
- create relay.ts and tests/relay_test.ts
- format code
- update relay_test.ts and lib/testing.ts
- refactor(core/websocket): refactor LazyWebSocket
- refactor(nodes): migrate to the new LazyWebSocket API
- to be squashed
- fix LazyWebSocket (to be squashed)
- Rough implementation of a MockWebSocket class for testing.
- Fix LazyWebSocket
- Fix the test for the NostrNode class
- Improve the MockWebSocket class to simulate a slow opening of a WebSocket as much as possible.
- test(client): update tests to use MockWebSocket
- test: do not rename MockWebSocket to WebSocket
- Add delay to MockWebSocket.close()
- Implementing relay
- Implement relay
- Format
