### PR TITLE
refactor: simplify modular architecture

### DIFF
--- a/core/clients.ts
+++ b/core/clients.ts
@@ -58,7 +58,7 @@ export class Client extends NostrNode<
     this.ws.addEventListener("message", (ev: MessageEvent<string>) => {
       const message = JSON.parse(ev.data) as ClientToRelayMessage;
       // TODO: Validate the message.
-      this.dispatchEvent(new ClientEvent("recieved", message));
+      this.dispatchEvent(new ClientEvent("message", message));
     });
   }
 }
@@ -68,7 +68,7 @@ export class Client extends NostrNode<
 // ------------------------------
 
 export interface ClientEventTypeRecord {
-  "recieved": ClientToRelayMessage;
+  "message": ClientToRelayMessage;
 }
 
 export type ClientEventType = keyof ClientEventTypeRecord;

--- a/core/clients.ts
+++ b/core/clients.ts
@@ -16,10 +16,11 @@ import { importNips } from "./nips.ts";
 // NIPs
 // ----------------------
 
-const NIPs = await importNips<RelayToClientMessage, ClientEventTypeRecord>(
-  import.meta.url,
-  "../nips",
-);
+const NIPs = await importNips<
+  RelayToClientMessage,
+  ClientEventTypeRecord,
+  Client
+>(import.meta.url, "../nips");
 
 // ----------------------
 // Interfaces
@@ -81,6 +82,7 @@ export class ClientEvent<
 // ------------------------------
 
 export type ClientModule = NostrNodeModule<
-  ClientToRelayMessage,
-  ClientEventTypeRecord
+  RelayToClientMessage,
+  ClientEventTypeRecord,
+  Client
 >;

--- a/core/clients.ts
+++ b/core/clients.ts
@@ -16,13 +16,20 @@ import { importNips } from "./nips.ts";
 // NIPs
 // ----------------------
 
-const NIPs = await importNips(import.meta.url, "../nips");
+const NIPs = await importNips<RelayToClientMessage, ClientEventTypeRecord>(
+  import.meta.url,
+  "../nips",
+);
 
 // ----------------------
 // Interfaces
 // ----------------------
 
-export type ClientConfig = NostrNodeConfig;
+export type ClientConfig = NostrNodeConfig<
+  RelayToClientMessage,
+  ClientEventTypeRecord
+>;
+
 export type ClientOptions = Partial<ClientConfig>;
 
 /**
@@ -73,4 +80,7 @@ export class ClientEvent<
 // Modules
 // ------------------------------
 
-export type ClientModule = NostrNodeModule<ClientToRelayMessage, ClientEventTypeRecord>;
+export type ClientModule = NostrNodeModule<
+  ClientToRelayMessage,
+  ClientEventTypeRecord
+>;

--- a/core/nips.ts
+++ b/core/nips.ts
@@ -1,5 +1,5 @@
 import type { NIP, NostrMessage } from "./protocol.d.ts";
-import { EventTypeRecord, NostrNodeModule } from "./nodes.ts";
+import { EventTypeRecord, NostrNode, NostrNodeModule } from "./nodes.ts";
 
 /**
  * Import a NostrNode module from a URL.
@@ -10,6 +10,7 @@ import { EventTypeRecord, NostrNodeModule } from "./nodes.ts";
 export function importNips<
   W extends NostrMessage = NostrMessage,
   R extends EventTypeRecord = EventTypeRecord,
+  N extends NostrNode<W, R> = NostrNode<W, R>,
 >(
   meta: string,
   root: string,
@@ -24,7 +25,7 @@ export function importNips<
             `${root}/${nipToString(nip)}/${base}`,
             import.meta.url,
           ).href
-        ) as Promise<NostrNodeModule<W, R>>,
+        ) as Promise<NostrNodeModule<W, R, N>>,
     ) ?? [],
   );
 }

--- a/core/nips.ts
+++ b/core/nips.ts
@@ -1,5 +1,5 @@
-import type { NIP } from "./protocol.d.ts";
-import { NostrNodeModule } from "./nodes.ts";
+import type { NIP, NostrMessage } from "./protocol.d.ts";
+import { EventTypeRecord, NostrNodeModule } from "./nodes.ts";
 
 /**
  * Import a NostrNode module from a URL.
@@ -7,7 +7,10 @@ import { NostrNodeModule } from "./nodes.ts";
  * @param meta - The path to the module to which the NIPs are attached (mostly import.meta.url).
  * @param root - The path to the root of NIP module to import.
  */
-export function importNips<M extends NostrNodeModule = NostrNodeModule>(
+export function importNips<
+  W extends NostrMessage = NostrMessage,
+  R extends EventTypeRecord = EventTypeRecord,
+>(
   meta: string,
   root: string,
 ) {
@@ -21,7 +24,7 @@ export function importNips<M extends NostrNodeModule = NostrNodeModule>(
             `${root}/${nipToString(nip)}/${base}`,
             import.meta.url,
           ).href
-        ) as Promise<M>,
+        ) as Promise<NostrNodeModule<W, R>>,
     ) ?? [],
   );
 }

--- a/core/nips.ts
+++ b/core/nips.ts
@@ -1,33 +1,30 @@
 import type { NIP } from "./protocol.d.ts";
 import { NostrNodeModule } from "./nodes.ts";
 
-export const NIPs = {
-  /**
-   * Import a Nostr module from a URL.
-   *
-   * @param meta - The path to the module to which the NIPs are attached (mostly import.meta.url).
-   * @param root - The path to the root of NIP module to import.
-   */
-  // deno-lint-ignore no-explicit-any
-  import<M extends NostrNodeModule<any>>(
-    meta: string,
-    root: string,
-  ) {
-    const url = new URL(meta);
-    const base = url.pathname.split("/").slice(-1)[0];
-    return Promise.all(
-      url.searchParams.get("nips")?.split(",").map(Number).map(
-        (nip) =>
-          import(
-            new URL(
-              `${root}/${nipToString(nip)}/${base}`,
-              import.meta.url,
-            ).href
-          ) as Promise<M>,
-      ) ?? [],
-    );
-  },
-};
+/**
+ * Import a NostrNode module from a URL.
+ *
+ * @param meta - The path to the module to which the NIPs are attached (mostly import.meta.url).
+ * @param root - The path to the root of NIP module to import.
+ */
+export function importNips(
+  meta: string,
+  root: string,
+) {
+  const url = new URL(meta);
+  const base = url.pathname.split("/").slice(-1)[0];
+  return Promise.all(
+    url.searchParams.get("nips")?.split(",").map(Number).map(
+      (nip) =>
+        import(
+          new URL(
+            `${root}/${nipToString(nip)}/${base}`,
+            import.meta.url,
+          ).href
+        ) as Promise<NostrNodeModule>,
+    ) ?? [],
+  );
+}
 
 /**
  * Convert a NIP to a string. If the NIP is less than 10, a leading zero is

--- a/core/nips.ts
+++ b/core/nips.ts
@@ -7,7 +7,7 @@ import { NostrNodeModule } from "./nodes.ts";
  * @param meta - The path to the module to which the NIPs are attached (mostly import.meta.url).
  * @param root - The path to the root of NIP module to import.
  */
-export function importNips(
+export function importNips<M extends NostrNodeModule = NostrNodeModule>(
   meta: string,
   root: string,
 ) {
@@ -21,7 +21,7 @@ export function importNips(
             `${root}/${nipToString(nip)}/${base}`,
             import.meta.url,
           ).href
-        ) as Promise<NostrNodeModule>,
+        ) as Promise<M>,
     ) ?? [],
   );
 }

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -74,7 +74,7 @@ export class NostrNode<
       listener as EventListenerOrEventListenerObject,
       { signal: this.#aborter.signal, ...options },
     );
-  };
+  }
 
   removeEventListener<T extends EventType<R>>(
     type: T,
@@ -88,11 +88,11 @@ export class NostrNode<
       listener as EventListenerOrEventListenerObject,
       options,
     );
-  };
+  }
 
   dispatchEvent<T extends EventType<R>>(event: NostrNodeEvent<R, T>) {
     return this.#eventTarget.dispatchEvent(event);
-  };
+  }
 }
 
 // ------------------------------
@@ -102,8 +102,9 @@ export class NostrNode<
 export interface NostrNodeModule<
   W extends NostrMessage = NostrMessage,
   R extends EventTypeRecord = EventTypeRecord,
+  N extends NostrNode<W, R> = NostrNode<W, R>,
 > {
-  default: (node: NostrNode<W, R>) => void;
+  default(node: N): void;
 }
 
 // ------------------------------

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -17,8 +17,8 @@ export class NostrNode<
   E extends EventDataTypeRecord = EventDataTypeRecord,
 > extends WritableStream<W> implements EventTarget {
   readonly #eventTarget = new EventTarget();
+  readonly #aborter = new AbortController();
   readonly config: Readonly<NostrNodeConfig>;
-  protected readonly aborter = new AbortController();
 
   constructor(
     readonly ws: WebSocketLike,
@@ -40,7 +40,7 @@ export class NostrNode<
   }
 
   async close() {
-    this.aborter.abort();
+    this.#aborter.abort();
     try {
       await super.close();
     } catch (err) {
@@ -58,7 +58,7 @@ export class NostrNode<
     return this.#eventTarget.addEventListener(
       type,
       listener as EventListenerOrEventListenerObject,
-      { signal: this.aborter.signal, ...options },
+      { signal: this.#aborter.signal, ...options },
     );
   };
 

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -118,7 +118,7 @@ export abstract class NostrNodeEvent<
 
 type EventType<E extends NostrNodeEvent> = E["type"];
 
-export type ExtractByType<
+type ExtractByType<
   E extends NostrNodeEvent,
   T extends E["type"],
 > = Extract<E, NostrNodeEvent<T>>;

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -58,7 +58,9 @@ export class NostrNode<
     }
   }
 
-  addModule = (module: NostrNodeModule<W, R>) => module.default(this);
+  addModule(module: NostrNodeModule<W, R>) { 
+    return module.default(this);
+  }
 
   addEventListener = <T extends EventType<R>>(
     type: T,
@@ -109,7 +111,7 @@ export interface NostrNodeModule<
 // ------------------------------
 
 // deno-lint-ignore no-empty-interface
-interface EventTypeRecord {}
+export interface EventTypeRecord {}
 
 type EventType<R extends EventTypeRecord> = keyof R & string;
 

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -50,9 +50,11 @@ export class NostrNode<
     }
   }
 
-  addEventListener = (
-    type: E["type"],
-    listener: NostrNodeEventListenerOrEventListenerObject<E> | null,
+  addEventListener = <T extends EventType<E>>(
+    type: T,
+    listener:
+      | NostrNodeEventListenerOrEventListenerObject<ExtractByType<E, T>>
+      | null,
     options?: AddEventListenerOptions,
   ) => {
     return this.#eventTarget.addEventListener(
@@ -62,9 +64,11 @@ export class NostrNode<
     );
   };
 
-  removeEventListener = (
-    type: E["type"],
-    listener: NostrNodeEventListenerOrEventListenerObject<E> | null,
+  removeEventListener = <T extends EventType<E>>(
+    type: T,
+    listener:
+      | NostrNodeEventListenerOrEventListenerObject<ExtractByType<E, T>>
+      | null,
     options?: boolean | EventListenerOptions,
   ) => {
     return this.#eventTarget.removeEventListener(
@@ -74,9 +78,7 @@ export class NostrNode<
     );
   };
 
-  dispatchEvent = (
-    event: E,
-  ) => {
+  dispatchEvent = (event: E) => {
     return this.#eventTarget.dispatchEvent(event);
   };
 }
@@ -113,6 +115,13 @@ export abstract class NostrNodeEvent<
     super(type, init);
   }
 }
+
+type EventType<E extends NostrNodeEvent> = E["type"];
+
+export type ExtractByType<
+  E extends NostrNodeEvent,
+  T extends E["type"],
+> = Extract<E, NostrNodeEvent<T>>;
 
 type NostrNodeEventListenerOrEventListenerObject<
   E extends NostrNodeEvent,

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -36,7 +36,7 @@ export class NostrNode<
       close: () => this.ws.close(),
     });
     this.config = { modules: [], logger: {}, nbuffer: 10, ...opts };
-    this.config.modules.forEach(this.addModule);
+    this.config.modules.forEach((m) => this.addModule(m));
   }
 
   send(msg: W) {
@@ -58,17 +58,17 @@ export class NostrNode<
     }
   }
 
-  addModule(module: NostrNodeModule<W, R>) { 
+  addModule(module: NostrNodeModule<W, R>) {
     return module.default(this);
   }
 
-  addEventListener = <T extends EventType<R>>(
+  addEventListener<T extends EventType<R>>(
     type: T,
     listener:
       | NostrNodeEventListenerOrEventListenerObject<W, R, T>
       | null,
     options?: AddEventListenerOptions,
-  ) => {
+  ) {
     return this.#eventTarget.addEventListener(
       type,
       listener as EventListenerOrEventListenerObject,
@@ -76,13 +76,13 @@ export class NostrNode<
     );
   };
 
-  removeEventListener = <T extends EventType<R>>(
+  removeEventListener<T extends EventType<R>>(
     type: T,
     listener:
       | NostrNodeEventListenerOrEventListenerObject<W, R, T>
       | null,
     options?: boolean | EventListenerOptions,
-  ) => {
+  ) {
     return this.#eventTarget.removeEventListener(
       type,
       listener as EventListenerOrEventListenerObject,
@@ -90,7 +90,7 @@ export class NostrNode<
     );
   };
 
-  dispatchEvent = <T extends EventType<R>>(event: NostrNodeEvent<R, T>) => {
+  dispatchEvent<T extends EventType<R>>(event: NostrNodeEvent<R, T>) {
     return this.#eventTarget.dispatchEvent(event);
   };
 }

--- a/core/nodes.ts
+++ b/core/nodes.ts
@@ -2,13 +2,19 @@ import type { NostrMessage } from "./protocol.d.ts";
 import type { Logger } from "./types.ts";
 import { WebSocketLike } from "./websockets.ts";
 
-export interface NostrNodeConfig {
-  modules: NostrNodeModule[];
+export interface NostrNodeConfig<
+  W extends NostrMessage = NostrMessage,
+  R extends EventTypeRecord = EventTypeRecord,
+> {
+  modules: NostrNodeModule<W, R>[];
   logger: Logger;
   nbuffer: number;
 }
 
-export type NostrNodeOptions = Partial<NostrNodeConfig>;
+export type NostrNodeOptions<
+  W extends NostrMessage = NostrMessage,
+  R extends EventTypeRecord = EventTypeRecord,
+> = Partial<NostrNodeConfig<W, R>>;
 
 /**
  * Common base class for relays and clients.
@@ -19,17 +25,18 @@ export class NostrNode<
 > extends WritableStream<W> implements EventTarget {
   readonly #eventTarget = new EventTarget();
   readonly #aborter = new AbortController();
-  readonly config: Readonly<NostrNodeConfig>;
+  readonly config: Readonly<NostrNodeConfig<W, R>>;
 
   constructor(
     readonly ws: WebSocketLike,
-    opts: NostrNodeOptions = {},
+    opts: NostrNodeOptions<W, R> = {},
   ) {
     super({
       write: (msg) => this.ws.send(JSON.stringify(msg)),
       close: () => this.ws.close(),
     });
     this.config = { modules: [], logger: {}, nbuffer: 10, ...opts };
+    this.config.modules.forEach(this.addModule);
   }
 
   send(msg: W) {
@@ -51,7 +58,7 @@ export class NostrNode<
     }
   }
 
-  install = (module: NostrNodeModule<W, R>) => module.default(this);
+  addModule = (module: NostrNodeModule<W, R>) => module.default(this);
 
   addEventListener = <T extends EventType<R>>(
     type: T,

--- a/core/relays.ts
+++ b/core/relays.ts
@@ -21,10 +21,11 @@ import { importNips } from "./nips.ts";
 // NIPs
 // ----------------------
 
-const NIPs = await importNips<ClientToRelayMessage, RelayEventTypeRecord>(
-  import.meta.url,
-  "../nips",
-);
+const NIPs = await importNips<
+  ClientToRelayMessage,
+  RelayEventTypeRecord,
+  Relay
+>(import.meta.url, "../nips");
 
 // ----------------------
 // Errors
@@ -202,5 +203,6 @@ export class RelayEvent<
 
 export type RelayModule = NostrNodeModule<
   ClientToRelayMessage,
-  RelayEventTypeRecord
+  RelayEventTypeRecord,
+  Relay
 >;

--- a/core/relays.ts
+++ b/core/relays.ts
@@ -156,7 +156,7 @@ export interface RelayLike extends WritableStream<ClientToRelayMessage> {
   publish: Relay["publish"];
 }
 
-export type RelayLikeConfig = Omit<RelayConfig, "url">;
+export type RelayLikeConfig = Pick<RelayConfig, "name" | "read" | "write">;
 export type RelayLikeOptions = Partial<RelayLikeConfig>;
 
 // ----------------------

--- a/core/relays.ts
+++ b/core/relays.ts
@@ -21,7 +21,10 @@ import { importNips } from "./nips.ts";
 // NIPs
 // ----------------------
 
-const NIPs = await importNips(import.meta.url, "../nips");
+const NIPs = await importNips<ClientToRelayMessage, RelayEventTypeRecord>(
+  import.meta.url,
+  "../nips",
+);
 
 // ----------------------
 // Errors
@@ -34,7 +37,8 @@ export class ConnectionClosed extends Error {}
 // Interfaces
 // ----------------------
 
-export interface RelayConfig extends NostrNodeConfig {
+export interface RelayConfig
+  extends NostrNodeConfig<ClientToRelayMessage, RelayEventTypeRecord> {
   url: RelayUrl;
   name: string;
   read: boolean;
@@ -105,13 +109,17 @@ export class Relay extends NostrNode<
     };
     return new ReadableStream<NostrEvent<K>>({
       start: (controller) => {
-        this.dispatchEvent(new RelayEvent("subscribe", { ...context, controller }));
+        this.dispatchEvent(
+          new RelayEvent("subscribe", { ...context, controller }),
+        );
       },
       pull: (controller) => {
         this.dispatchEvent(new RelayEvent("pull", { ...context, controller }));
       },
       cancel: (reason) => {
-        this.dispatchEvent(new RelayEvent("unsubscribe", { ...context, reason }));
+        this.dispatchEvent(
+          new RelayEvent("unsubscribe", { ...context, reason }),
+        );
       },
     }, new CountQueuingStrategy({ highWaterMark: options.nbuffer }));
   }
@@ -192,4 +200,7 @@ export class RelayEvent<
 // Modules
 // ----------------------
 
-export type RelayModule = NostrNodeModule<ClientToRelayMessage, RelayEventTypeRecord>;
+export type RelayModule = NostrNodeModule<
+  ClientToRelayMessage,
+  RelayEventTypeRecord
+>;

--- a/core/relays.ts
+++ b/core/relays.ts
@@ -192,4 +192,4 @@ export class RelayEvent<
 // Modules
 // ----------------------
 
-export type RelayModule = NostrNodeModule<ClientToRelayMessage, RelayEvent>;
+export type RelayModule = NostrNodeModule<ClientToRelayMessage, RelayEventTypeRecord>;

--- a/nips/01/clients_test.ts
+++ b/nips/01/clients_test.ts
@@ -31,7 +31,7 @@ describe("NIP-01/Client", () => {
   it("should receive an event and send a OK message", async () => {
     const event = { id: "test-ok", kind: 0 };
     const received = new Promise<ClientToRelayMessage<"EVENT">>((resolve) => {
-      client.addFunction("handleClientToRelayMessage", ({ message }) => {
+      client.addEventListener("message", ({ data: message }) => {
         if (message[0] === "EVENT") resolve(message);
       });
     });
@@ -49,7 +49,7 @@ describe("NIP-01/Client", () => {
     subid = "test-req" as SubscriptionId;
     const request: ClientToRelayMessage<"REQ"> = ["REQ", subid, { kinds: [1] }];
     const received = new Promise<ClientToRelayMessage<"REQ">>((resolve) => {
-      client.addFunction("handleClientToRelayMessage", ({ message }) => {
+      client.addEventListener("message", ({ data: message }) => {
         if (message[0] === "REQ" && message[1] === subid) resolve(message);
       });
     });

--- a/nips/01/relays.ts
+++ b/nips/01/relays.ts
@@ -1,13 +1,76 @@
-import { EventRejected, RelayModuleInstaller } from "../../core/relays.ts";
+import type {
+  EventId,
+  RelayToClientMessage,
+  RelayToClientMessageType,
+  SubscriptionId,
+} from "../../core/protocol.d.ts";
+import { NostrNodeEvent } from "../../core/nodes.ts";
+import { RelayModuleInstaller } from "../../core/relays.ts";
 
-const install: RelayModuleInstaller = (relay) => {
+const install: RelayModuleInstaller<RelayModuleEvent> = (relay) => {
+  relay.addEventListener("message", ({ data: message }) => {
+    switch (message[0]) {
+      case "EVENT":
+      case "EOSE": {
+        return relay.dispatchEvent(new EventReceived(message));
+      }
+      case "OK": {
+        return relay.dispatchEvent(new EventAccepted(message));
+      }
+      case "NOTICE": {
+        return relay.config?.logger?.info?.(message[1]);
+      }
+    }
+  });
   relay.addEventListener("subscribe", (ev) => {
-    const { controller } = ev.data;
-    controller.close();
+    const { id, filters, options, controller } = ev.data;
+    relay.addEventListener(id, ({ data: message }) => {
+      switch (message[0]) {
+        case "EVENT": {
+          const [, , event] = message;
+          return controller.enqueue(event);
+        }
+        case "EOSE": {
+          if (!options.realtime) {
+            return controller.close();
+          }
+        }
+      }
+    });
+    return relay.send(["REQ", id, ...filters]);
   });
 };
 
-export default {
+export default install;
+
+type RelayModuleEvent = EventReceived | EventAccepted;
+
+class EventReceived
+  extends NostrNodeEvent<SubscriptionId, SubscriptionMessage> {
+  constructor(data: SubscriptionMessage) {
+    super(data[1], { data });
+  }
+}
+
+class EventAccepted extends NostrNodeEvent<EventId, PublicationMessage> {
+  constructor(data: PublicationMessage) {
+    super(data[1], { data });
+  }
+}
+
+type SubscriptionMessage = {
+  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends
+    SubscriptionId ? RelayToClientMessage<T> : never;
+}[RelayToClientMessageType];
+
+type PublicationMessage = {
+  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends EventId
+    ? RelayToClientMessage<T>
+    : never;
+}[RelayToClientMessageType];
+
+/**
+export {
   handleRelayToClientMessage({ message, relay }) {
     const type = message[0];
     relay.config.logger?.debug?.(relay.config.name, message);
@@ -75,3 +138,4 @@ export default {
     }
   },
 } satisfies RelayModule["default"];
+*/

--- a/nips/01/relays.ts
+++ b/nips/01/relays.ts
@@ -5,7 +5,33 @@ import type {
   SubscriptionId,
 } from "../../core/protocol.d.ts";
 import { NostrNodeEvent } from "../../core/nodes.ts";
-import { RelayModuleInstaller } from "../../core/relays.ts";
+import { EventRejected, RelayModuleInstaller } from "../../core/relays.ts";
+
+type RelayModuleEvent = EventReceived | EventAccepted;
+
+class EventReceived
+  extends NostrNodeEvent<SubscriptionId, SubscriptionMessage> {
+  constructor(data: SubscriptionMessage) {
+    super(data[1], { data });
+  }
+}
+
+class EventAccepted extends NostrNodeEvent<EventId, PublicationMessage> {
+  constructor(data: PublicationMessage) {
+    super(data[1], { data });
+  }
+}
+
+type SubscriptionMessage = {
+  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends
+    SubscriptionId ? RelayToClientMessage<T> : never;
+}[RelayToClientMessageType];
+
+type PublicationMessage = {
+  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends EventId
+    ? RelayToClientMessage<T>
+    : never;
+}[RelayToClientMessageType];
 
 const install: RelayModuleInstaller<RelayModuleEvent> = (relay) => {
   relay.addEventListener("message", ({ data: message }) => {
@@ -39,103 +65,26 @@ const install: RelayModuleInstaller<RelayModuleEvent> = (relay) => {
     });
     return relay.send(["REQ", id, ...filters]);
   });
+  relay.addEventListener("unsubscribe", ({ data: { id } }) => {
+    if (relay.status === WebSocket.OPEN) {
+      return relay.send(["CLOSE", id]);
+    }
+  });
+  relay.addEventListener("publish", (ev) => {
+    const { event, resolve, reject } = ev.data;
+    relay.addEventListener(event.id, ({ data: message }) => {
+      if (message[0] !== "OK") {
+        // This NIP only supports OK messages.
+        return;
+      }
+      const [, , accepted, reason] = message;
+      if (accepted) {
+        return resolve();
+      }
+      reject(new EventRejected(reason, { cause: event }));
+    });
+    return relay.send(["EVENT", event]);
+  });
 };
 
 export default install;
-
-type RelayModuleEvent = EventReceived | EventAccepted;
-
-class EventReceived
-  extends NostrNodeEvent<SubscriptionId, SubscriptionMessage> {
-  constructor(data: SubscriptionMessage) {
-    super(data[1], { data });
-  }
-}
-
-class EventAccepted extends NostrNodeEvent<EventId, PublicationMessage> {
-  constructor(data: PublicationMessage) {
-    super(data[1], { data });
-  }
-}
-
-type SubscriptionMessage = {
-  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends
-    SubscriptionId ? RelayToClientMessage<T> : never;
-}[RelayToClientMessageType];
-
-type PublicationMessage = {
-  [T in RelayToClientMessageType]: RelayToClientMessage<T>[1] extends EventId
-    ? RelayToClientMessage<T>
-    : never;
-}[RelayToClientMessageType];
-
-/**
-export {
-  handleRelayToClientMessage({ message, relay }) {
-    const type = message[0];
-    relay.config.logger?.debug?.(relay.config.name, message);
-    switch (type) {
-      case "EVENT":
-      case "EOSE": {
-        const sid = message[1];
-        return relay.dispatchEvent(
-          new RelaySubscriptionEvent(sid, { data: message }),
-        );
-      }
-      case "OK": {
-        const eid = message[1];
-        return relay.dispatchEvent(
-          new PublicationEvent(eid, { data: message }),
-        );
-      }
-      case "NOTICE": {
-        const notice = message[1];
-        return relay.config?.logger?.info?.(notice);
-      }
-    }
-  },
-
-  handleSubscriptionMessage({ message, options, controller }) {
-    const type = message[0];
-    switch (type) {
-      case "EVENT": {
-        const [, , event] = message;
-        return controller.enqueue(event);
-      }
-      case "EOSE": {
-        if (!options.realtime) {
-          return controller.close();
-        }
-      }
-    }
-  },
-
-  handlePublicationMessage({ message, event }) {
-    const type = message[0];
-    if (type !== "OK") {
-      // This NIP only supports OK messages.
-      return;
-    }
-    const accepted = message[2];
-    if (accepted) {
-      return;
-    }
-    const reason = message[3];
-    throw new EventRejected(reason, { cause: event });
-  },
-
-  publishEvent({ event, relay }) {
-    return relay.send(["EVENT", event]);
-  },
-
-  startSubscription({ filters, id, relay }) {
-    return relay.send(["REQ", id, ...filters]);
-  },
-
-  closeSubscription({ id, relay }) {
-    if (relay.ws.readyState === WebSocket.OPEN) {
-      return relay.send(["CLOSE", id]);
-    }
-  },
-} satisfies RelayModule["default"];
-*/

--- a/nips/01/relays.ts
+++ b/nips/01/relays.ts
@@ -1,9 +1,11 @@
-import {
-  EventRejected,
-  PublicationEvent,
-  RelayModule,
-  RelaySubscriptionEvent,
-} from "../../core/relays.ts";
+import { EventRejected, RelayModuleInstaller } from "../../core/relays.ts";
+
+const install: RelayModuleInstaller = (relay) => {
+  relay.addEventListener("subscribe", (ev) => {
+    const { controller } = ev.data;
+    controller.close();
+  });
+};
 
 export default {
   handleRelayToClientMessage({ message, relay }) {

--- a/nips/42/protocol.d.ts
+++ b/nips/42/protocol.d.ts
@@ -1,6 +1,5 @@
 import "../../core/protocol.d.ts";
 import "../../core/relays.ts";
-import type { Signer } from "../../lib/signs.ts";
 
 declare module "../../core/protocol.d.ts" {
   interface NipRecord {
@@ -27,11 +26,5 @@ declare module "../../core/protocol.d.ts" {
   interface TagRecord {
     "relay": [RelayUrl];
     "challenge": [string];
-  }
-}
-
-declare module "../../core/relays.ts" {
-  interface RelayConfig {
-    signer?: Signer;
   }
 }

--- a/nips/42/relays.ts
+++ b/nips/42/relays.ts
@@ -1,12 +1,18 @@
 import type { Stringified } from "../../core/types.ts";
 import type { RelayModule } from "../../core/relays.ts";
 import type { EventInit } from "../../lib/events.ts";
+import type { Signer } from "../../lib/signs.ts";
 import "./protocol.d.ts";
 
-export default {
-  handleRelayToClientMessage({ message, relay }) {
-    const type = message[0];
-    if (type !== "AUTH") {
+declare module "../../core/relays.ts" {
+  interface RelayConfig {
+    signer?: Signer;
+  }
+}
+
+const install: RelayModule["default"] = (relay) => {
+  relay.addEventListener("message", ({ data: message }) => {
+    if (message[0] !== "AUTH") {
       // This NIP only handles AUTH messages
       return;
     }
@@ -23,5 +29,7 @@ export default {
       content: "" as Stringified<"">,
     };
     return relay.publish(relay.config.signer.sign(event));
-  },
-} satisfies RelayModule["default"];
+  });
+};
+
+export default install;


### PR DESCRIPTION
- simplify nodes.ts
- nodes: make aborter hard-private
- further simplification of nodes
- relays: migrating to new APIs
- refactoring relays
- refactor nip01 relays
- simplification
- wip
- update core/clients.ts
- implement `addModule` in nodes
- core modules to pass checks
- fix nodes for nip01 relays to pass tests
- fix NostrNodeModule to pass Relay or Client
- update nip01 clients to pass test
- fix core/relays for lib/relays to pass test
- update nip42 relays to pass test
